### PR TITLE
Benchmark moor_ffi

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,2 +1,1 @@
 org.gradle.jvmargs=-Xmx1536M
-android.enableR8=true

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.jvmargs=-Xmx1536M
+android.enableR8=true

--- a/lib/benchmark.dart
+++ b/lib/benchmark.dart
@@ -21,8 +21,8 @@ class Result {
 final runners = [
   HiveRunner(false),
   HiveRunner(true),
-//  SqfliteRunner(),
-//  SharedPreferencesRunner(),
+  SqfliteRunner(),
+  SharedPreferencesRunner(),
   MoorFfiRunner(),
 ];
 

--- a/lib/benchmark.dart
+++ b/lib/benchmark.dart
@@ -1,19 +1,33 @@
-import 'dart:io';
 import 'dart:math';
 
-import 'package:hive/hive.dart';
-import 'package:hive_benchmark/sqlite_store.dart';
-import 'package:path/path.dart' as path;
-import 'package:path_provider/path_provider.dart';
+import 'package:hive_benchmark/runners/hive.dart';
+import 'package:hive_benchmark/runners/moor_ffi.dart';
+import 'package:hive_benchmark/runners/runner.dart';
+import 'package:hive_benchmark/runners/shared_preferences.dart';
+import 'package:hive_benchmark/runners/sqflite.dart';
 import 'package:random_string/random_string.dart' as randStr;
-import 'package:shared_preferences/shared_preferences.dart';
 
 const String TABLE_NAME_STR = "kv_str";
 const String TABLE_NAME_INT = "kv_int";
 
 class Result {
+  final BenchmarkRunner runner;
   int intTime;
   int stringTime;
+
+  Result(this.runner);
+}
+
+final runners = [
+  HiveRunner(false),
+  HiveRunner(true),
+//  SqfliteRunner(),
+//  SharedPreferencesRunner(),
+  MoorFfiRunner(),
+];
+
+List<Result> _createResults() {
+  return runners.map((r) => Result(r)).toList();
 }
 
 Map<String, int> generateIntEntries(int count) {
@@ -37,256 +51,70 @@ Map<String, String> generateStringEntries(int count) {
   return map;
 }
 
-Future prepareHive() async {
-  var dir = await getApplicationDocumentsDirectory();
-  var homePath = path.join(dir.path, 'hive');
-  if (await Directory(homePath).exists()) {
-    await Directory(homePath).delete(recursive: true);
-  }
-  await Directory(homePath).create();
-  Hive.init(homePath);
-}
-
-Future<SqfliteStore> getSqliteStore() async {
-  var store = SqfliteStore();
-  await store.init();
-  return store;
-}
-
-Future prepareSharedPrefs() async {
-  var prefs = await SharedPreferences.getInstance();
-  await prefs.clear();
-}
-
-Future<int> hiveBatchRead(List<String> keys, bool lazy) async {
-  var box = await Hive.openBox('box', lazy: lazy);
-  var s = Stopwatch()..start();
-  for (var key in keys) {
-    box.get(key);
-  }
-  s.stop();
-  await box.close();
-  return s.elapsedMilliseconds;
-}
-
-Future<int> sqliteBatchReadInt(SqfliteStore store, List<String> keys) async {
-  var s = Stopwatch()..start();
-  for (var key in keys) {
-    await store.getInt(key);
-  }
-  s.stop();
-  return s.elapsedMilliseconds;
-}
-
-Future<int> sqliteBatchReadString(SqfliteStore store, List<String> keys) async {
-  var s = Stopwatch()..start();
-  for (var key in keys) {
-    await store.getString(key);
-  }
-  s.stop();
-  return s.elapsedMilliseconds;
-}
-
-Future<int> sharedPrefsBatchReadInt(List<String> keys) async {
-  var prefs = await SharedPreferences.getInstance();
-  var s = Stopwatch()..start();
-  for (var key in keys) {
-    prefs.getInt(key);
-  }
-  s.stop();
-  return s.elapsedMilliseconds;
-}
-
-Future<int> sharedPrefsReadString(List<String> keys) async {
-  var prefs = await SharedPreferences.getInstance();
-  var s = Stopwatch()..start();
-  for (var key in keys) {
-    prefs.getString(key);
-  }
-  s.stop();
-  return s.elapsedMilliseconds;
-}
-
 Future<List<Result>> benchmarkRead(int count) async {
-  var results = [Result(), Result(), Result(), Result()];
-  await prepareHive();
-  var store = await getSqliteStore();
-  await prepareSharedPrefs();
+  var results = _createResults();
 
   var intEntries = generateIntEntries(count);
   var intKeys = intEntries.keys.toList()..shuffle();
-  await hiveBatchWrite(intEntries);
-  await sqliteBatchWriteInt(store, intEntries);
-  await sharedPrefsBatchWriteInt(intEntries);
-  results[0].intTime = await hiveBatchRead(intKeys, false);
-  results[1].intTime = await hiveBatchRead(intKeys, true);
-  results[2].intTime = await sqliteBatchReadInt(store, intKeys);
-  results[3].intTime = await sharedPrefsBatchReadInt(intKeys);
 
-  await prepareHive();
-  await prepareSharedPrefs();
+  for (var result in results) {
+    await result.runner.setUp();
+    await result.runner.batchWriteInt(intEntries);
+    result.intTime = await result.runner.batchReadInt(intKeys);
+  }
 
   var stringEntries = generateStringEntries(count);
   var stringKeys = stringEntries.keys.toList()..shuffle();
-  await hiveBatchWrite(stringEntries);
-  await sqliteBatchWriteString(store, stringEntries);
-  await sharedPrefsBatchWriteString(stringEntries);
-  results[0].stringTime = await hiveBatchRead(stringKeys, false);
-  results[1].stringTime = await hiveBatchRead(stringKeys, true);
-  results[2].stringTime = await sqliteBatchReadString(store, stringKeys);
-  results[3].stringTime = await sharedPrefsReadString(stringKeys);
 
-  await Hive.close();
-  await store.close();
+  for (var result in results) {
+    await result.runner.batchWriteString(stringEntries);
+    result.stringTime = await result.runner.batchReadString(stringKeys);
+  }
+
+  for (var result in results) {
+    await result.runner.tearDown();
+  }
 
   return results;
-}
-
-Future<int> hiveBatchWrite(Map<String, dynamic> entries) async {
-  var box = await Hive.openBox('box', lazy: true);
-  var s = Stopwatch()..start();
-  for (var key in entries.keys) {
-    await box.put(key, entries[key]);
-  }
-  s.stop();
-  await box.close();
-  return s.elapsedMilliseconds;
-}
-
-Future<int> sqliteBatchWriteInt(
-    SqfliteStore store, Map<String, int> entries) async {
-  var s = Stopwatch()..start();
-  for (var key in entries.keys) {
-    await store.putInt(key, entries[key]);
-  }
-  s.stop();
-  return s.elapsedMilliseconds;
-}
-
-Future<int> sqliteBatchWriteString(
-    SqfliteStore store, Map<String, String> entries) async {
-  var s = Stopwatch()..start();
-  for (var key in entries.keys) {
-    await store.putString(key, entries[key]);
-  }
-  s.stop();
-  return s.elapsedMilliseconds;
-}
-
-Future<int> sharedPrefsBatchWriteInt(Map<String, int> entries) async {
-  var s = Stopwatch()..start();
-  var prefs = await SharedPreferences.getInstance();
-  for (var key in entries.keys) {
-    await prefs.setInt(key, entries[key]);
-  }
-  s.stop();
-  return s.elapsedMilliseconds;
-}
-
-Future<int> sharedPrefsBatchWriteString(Map<String, String> entries) async {
-  var s = Stopwatch()..start();
-  var prefs = await SharedPreferences.getInstance();
-  for (var key in entries.keys) {
-    await prefs.setString(key, entries[key]);
-  }
-  s.stop();
-  return s.elapsedMilliseconds;
 }
 
 Future<List<Result>> benchmarkWrite(int count) async {
-  var results = [Result(), Result(), Result()];
-  await prepareHive();
-  var store = await getSqliteStore();
-  await prepareSharedPrefs();
-
+  final results = _createResults();
   var intEntries = generateIntEntries(count);
-  results[0].intTime = await hiveBatchWrite(intEntries);
-  results[1].intTime = await sqliteBatchWriteInt(store, intEntries);
-  results[2].intTime = await sharedPrefsBatchWriteInt(intEntries);
-
-  await prepareHive();
-  await prepareSharedPrefs();
-
   var stringEntries = generateStringEntries(count);
-  results[0].stringTime = await hiveBatchWrite(stringEntries);
-  results[1].stringTime = await sqliteBatchWriteString(store, stringEntries);
-  results[2].stringTime = await sharedPrefsBatchWriteString(stringEntries);
 
-  await Hive.close();
-  await store.close();
+  for (var result in results) {
+    await result.runner.setUp();
+    result.intTime = await result.runner.batchWriteInt(intEntries);
+    result.stringTime = await result.runner.batchWriteString(stringEntries);
+
+    await result.runner.tearDown();
+  }
 
   return results;
 }
 
-Future<int> hiveBatchDelete(List<String> keys) async {
-  var box = await Hive.openBox('box', lazy: true);
-  var s = Stopwatch()..start();
-  for (var key in keys) {
-    await box.delete(key);
-  }
-  s.stop();
-  await box.close();
-  return s.elapsedMilliseconds;
-}
-
-Future<int> sqliteBatchDeleteInt(SqfliteStore store, List<String> keys) async {
-  var s = Stopwatch()..start();
-  for (var key in keys) {
-    await store.deleteInt(key);
-  }
-  s.stop();
-  return s.elapsedMilliseconds;
-}
-
-Future<int> sqliteBatchDeleteString(
-    SqfliteStore store, List<String> keys) async {
-  var s = Stopwatch()..start();
-  for (var key in keys) {
-    await store.deleteString(key);
-  }
-  s.stop();
-  return s.elapsedMilliseconds;
-}
-
-Future<int> sharedPrefsBatchDelete(List<String> keys) async {
-  var s = Stopwatch()..start();
-  var prefs = await SharedPreferences.getInstance();
-  for (var key in keys) {
-    await prefs.remove(key);
-  }
-  s.stop();
-  return s.elapsedMilliseconds;
-}
-
 Future<List<Result>> benchmarkDelete(int count) async {
-  var results = [Result(), Result(), Result()];
-  await prepareHive();
-  var store = await getSqliteStore();
-  await prepareSharedPrefs();
+  final results = _createResults();
 
   var intEntries = generateIntEntries(count);
   var intKeys = intEntries.keys.toList()..shuffle();
-  await hiveBatchWrite(intEntries);
-  await sqliteBatchWriteInt(store, intEntries);
-  await sharedPrefsBatchWriteInt(intEntries);
-  results[0].intTime = await hiveBatchDelete(intKeys);
-  results[1].intTime = await sqliteBatchDeleteInt(store, intKeys);
-  results[2].intTime = await sharedPrefsBatchDelete(intKeys);
-
-  await prepareHive();
-  await prepareSharedPrefs();
+  for (var result in results) {
+    await result.runner.setUp();
+    await result.runner.batchWriteInt(intEntries);
+    result.intTime = await result.runner.batchDeleteInt(intKeys);
+  }
 
   var stringEntries = generateStringEntries(count);
   var stringKeys = stringEntries.keys.toList()..shuffle();
-  await hiveBatchWrite(stringEntries);
-  await sqliteBatchWriteString(store, stringEntries);
-  await sharedPrefsBatchWriteString(stringEntries);
-  results[0].stringTime = await hiveBatchDelete(stringKeys);
-  results[1].stringTime = await sqliteBatchDeleteString(store, stringKeys);
-  results[2].stringTime = await sharedPrefsBatchDelete(stringKeys);
+  for (var result in results) {
+    await result.runner.batchWriteString(stringEntries);
+    result.stringTime = await result.runner.batchDeleteString(stringKeys);
+  }
 
-  await Hive.close();
-  await store.close();
+  for (var result in results) {
+    await result.runner.tearDown();
+  }
 
   return results;
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,3 @@
-import 'dart:collection';
-import 'dart:io';
 import 'dart:math';
 
 import 'package:fl_chart/fl_chart.dart';
@@ -178,11 +176,7 @@ class BenchmarkResult extends StatelessWidget {
   BenchmarkResult(this.results);
 
   List<String> get labels {
-    if (results.length == 3) {
-      return ['Hive', 'SQLite', 'S.Prefs'];
-    } else {
-      return ['Hive', 'Lazy Hive', 'SQLite', 'S.Prefs'];
-    }
+    return results.map((r) => r.runner.name).toList();
   }
 
   int get maxResultTime {

--- a/lib/runners/hive.dart
+++ b/lib/runners/hive.dart
@@ -51,7 +51,7 @@ class HiveRunner implements BenchmarkRunner {
 
   @override
   Future<int> batchWriteString(Map<String, dynamic> entries) async {
-    var box = await Hive.openBox('box', lazy: true);
+    var box = await Hive.openBox('box', lazy: lazy);
     var s = Stopwatch()..start();
     for (var key in entries.keys) {
       await box.put(key, entries[key]);
@@ -68,7 +68,7 @@ class HiveRunner implements BenchmarkRunner {
 
   @override
   Future<int> batchDeleteInt(List<String> keys) async {
-    var box = await Hive.openBox('box', lazy: true);
+    var box = await Hive.openBox('box', lazy: lazy);
     var s = Stopwatch()..start();
     for (var key in keys) {
       await box.delete(key);

--- a/lib/runners/hive.dart
+++ b/lib/runners/hive.dart
@@ -1,0 +1,85 @@
+import 'dart:io';
+
+import 'package:hive/hive.dart';
+import 'package:hive_benchmark/runners/runner.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:path/path.dart' as path;
+
+class HiveRunner implements BenchmarkRunner {
+  final bool lazy;
+
+  HiveRunner(this.lazy);
+
+  @override
+  String get name => lazy ? 'Hive (lazy)' : 'Hive';
+
+  @override
+  Future<void> setUp() async {
+    if (lazy) return; // only do this work in the non-lazy runner
+
+    var dir = await getApplicationDocumentsDirectory();
+    var homePath = path.join(dir.path, 'hive');
+    if (await Directory(homePath).exists()) {
+      await Directory(homePath).delete(recursive: true);
+    }
+    await Directory(homePath).create();
+    Hive.init(homePath);
+  }
+
+  @override
+  Future<void> tearDown() async {
+    if (lazy) return;
+    await Hive.close();
+  }
+
+  @override
+  Future<int> batchReadInt(List<String> keys) async {
+    final box = await Hive.openBox('box', lazy: lazy);
+    final s = Stopwatch()..start();
+    for (var key in keys) {
+      box.get(key);
+    }
+    s.stop();
+    await box.close();
+    return s.elapsedMilliseconds;
+  }
+
+  @override
+  Future<int> batchReadString(List<String> keys) {
+    return batchReadInt(keys); // implementation is the same for hive
+  }
+
+  @override
+  Future<int> batchWriteString(Map<String, dynamic> entries) async {
+    var box = await Hive.openBox('box', lazy: true);
+    var s = Stopwatch()..start();
+    for (var key in entries.keys) {
+      await box.put(key, entries[key]);
+    }
+    s.stop();
+    await box.close();
+    return s.elapsedMilliseconds;
+  }
+
+  @override
+  Future<int> batchWriteInt(Map<String, int> entries) {
+    return batchWriteString(entries);
+  }
+
+  @override
+  Future<int> batchDeleteInt(List<String> keys) async {
+    var box = await Hive.openBox('box', lazy: true);
+    var s = Stopwatch()..start();
+    for (var key in keys) {
+      await box.delete(key);
+    }
+    s.stop();
+    await box.close();
+    return s.elapsedMilliseconds;
+  }
+
+  @override
+  Future<int> batchDeleteString(List<String> keys) {
+    return batchDeleteInt(keys);
+  }
+}

--- a/lib/runners/moor_ffi.dart
+++ b/lib/runners/moor_ffi.dart
@@ -1,0 +1,116 @@
+import 'dart:io';
+
+import 'package:hive_benchmark/runners/runner.dart';
+import 'package:moor_ffi/database.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:path/path.dart' as path;
+
+import '../benchmark.dart';
+
+class MoorFfiRunner implements BenchmarkRunner {
+  @override
+  String get name => 'SQL (ffi)';
+
+  Database db;
+
+  @override
+  Future<void> setUp() async {
+    var dir = await getApplicationDocumentsDirectory();
+    var homePath = path.join(dir.path, 'ffi.db');
+    final file = File(homePath);
+
+    if (await file.exists()) {
+      await file.delete();
+    }
+
+    db = Database.openFile(file);
+
+    db.execute(
+        'CREATE TABLE $TABLE_NAME_STR (key TEXT PRIMARY KEY, value TEXT)');
+    db.execute(
+        'CREATE TABLE $TABLE_NAME_INT (key TEXT PRIMARY KEY, value INTEGER)');
+  }
+
+  @override
+  Future<void> tearDown() async {
+    db.close();
+  }
+
+  Future<int> _batchRead(String table, List<String> keys) async {
+    var s = Stopwatch()..start();
+    final stmt = db.prepare('SELECT * FROM $table WHERE key = ?');
+
+    for (var key in keys) {
+      final result = stmt.select([key]);
+      // read all rows because that would be required during a real read
+      result.forEach((row) => row['value']);
+    }
+
+    s.stop();
+    stmt.close();
+    return s.elapsedMilliseconds;
+  }
+
+  @override
+  Future<int> batchReadInt(List<String> keys) async {
+    return _batchRead(TABLE_NAME_INT, keys);
+  }
+
+  @override
+  Future<int> batchReadString(List<String> keys) {
+    return _batchRead(TABLE_NAME_STR, keys);
+  }
+
+  @override
+  Future<int> batchWriteInt(Map<String, int> entries) async {
+    var s = Stopwatch()..start();
+    final stmt = db.prepare(
+        'INSERT OR REPLACE INTO $TABLE_NAME_INT (key, value) VALUES (?, ?)');
+
+    entries.forEach((key, value) {
+      stmt.execute([key, value]);
+    });
+
+    stmt.close();
+    s.stop();
+    return s.elapsedMilliseconds;
+  }
+
+  @override
+  Future<int> batchWriteString(Map<String, String> entries) async {
+    var s = Stopwatch()..start();
+    final stmt = db.prepare(
+        'INSERT OR REPLACE INTO $TABLE_NAME_STR (key, value) VALUES (?, ?)');
+
+    entries.forEach((key, value) {
+      stmt.execute([key, value]);
+    });
+
+    stmt.close();
+    s.stop();
+    return s.elapsedMilliseconds;
+  }
+
+  Future<int> _deleteFromTable(String table, List<String> keys) async {
+    var s = Stopwatch()..start();
+    final stmt = db.prepare('DELETE FROM $table WHERE key = ?');
+
+    for (var key in keys) {
+      stmt.execute([key]);
+    }
+
+    stmt.close();
+    s.stop();
+    return s.elapsedMilliseconds;
+  }
+
+  @override
+  Future<int> batchDeleteInt(List<String> keys) {
+    return _deleteFromTable(TABLE_NAME_INT, keys);
+  }
+
+  @override
+  Future<int> batchDeleteString(List<String> keys) {
+    return _deleteFromTable(TABLE_NAME_STR, keys);
+  }
+}

--- a/lib/runners/runner.dart
+++ b/lib/runners/runner.dart
@@ -1,0 +1,13 @@
+abstract class BenchmarkRunner {
+  String get name;
+
+  Future<void> setUp();
+  Future<void> tearDown();
+
+  Future<int> batchReadInt(List<String> keys);
+  Future<int> batchReadString(List<String> keys);
+  Future<int> batchWriteInt(Map<String, int> entries);
+  Future<int> batchWriteString(Map<String, String> entries);
+  Future<int> batchDeleteInt(List<String> keys);
+  Future<int> batchDeleteString(List<String> keys);
+}

--- a/lib/runners/shared_preferences.dart
+++ b/lib/runners/shared_preferences.dart
@@ -1,0 +1,80 @@
+import 'package:hive_benchmark/runners/runner.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SharedPreferencesRunner implements BenchmarkRunner {
+  SharedPreferences prefs;
+
+  @override
+  String get name => 'Shared Preferences';
+
+  @override
+  Future<void> setUp() async {
+    prefs = await SharedPreferences.getInstance();
+    await prefs.clear();
+  }
+
+  @override
+  Future<void> tearDown() async {
+    // nothing to do here, cleared in setUp
+  }
+
+  @override
+  Future<int> batchReadInt(List<String> keys) async {
+    var prefs = await SharedPreferences.getInstance();
+    var s = Stopwatch()..start();
+    for (var key in keys) {
+      prefs.getInt(key);
+    }
+    s.stop();
+    return s.elapsedMilliseconds;
+  }
+
+  @override
+  Future<int> batchReadString(List<String> keys) async {
+    var prefs = await SharedPreferences.getInstance();
+    var s = Stopwatch()..start();
+    for (var key in keys) {
+      prefs.getString(key);
+    }
+    s.stop();
+    return s.elapsedMilliseconds;
+  }
+
+  @override
+  Future<int> batchWriteInt(Map<String, int> entries) async {
+    var s = Stopwatch()..start();
+    var prefs = await SharedPreferences.getInstance();
+    for (var key in entries.keys) {
+      await prefs.setInt(key, entries[key]);
+    }
+    s.stop();
+    return s.elapsedMilliseconds;
+  }
+
+  @override
+  Future<int> batchWriteString(Map<String, String> entries) async {
+    var s = Stopwatch()..start();
+    var prefs = await SharedPreferences.getInstance();
+    for (var key in entries.keys) {
+      await prefs.setString(key, entries[key]);
+    }
+    s.stop();
+    return s.elapsedMilliseconds;
+  }
+
+  @override
+  Future<int> batchDeleteInt(List<String> keys) async {
+    var s = Stopwatch()..start();
+    var prefs = await SharedPreferences.getInstance();
+    for (var key in keys) {
+      await prefs.remove(key);
+    }
+    s.stop();
+    return s.elapsedMilliseconds;
+  }
+
+  @override
+  Future<int> batchDeleteString(List<String> keys) {
+    return batchDeleteInt(keys);
+  }
+}

--- a/lib/runners/sqflite.dart
+++ b/lib/runners/sqflite.dart
@@ -1,0 +1,81 @@
+import 'package:hive_benchmark/runners/runner.dart';
+
+import '../sqlite_store.dart';
+
+class SqfliteRunner implements BenchmarkRunner {
+  SqfliteStore store;
+
+  @override
+  String get name => 'sqflite';
+
+  @override
+  Future<void> setUp() async {
+    store = SqfliteStore();
+    await store.init();
+  }
+
+  @override
+  Future<void> tearDown() async {
+    await store.close();
+  }
+
+  @override
+  Future<int> batchReadInt(List<String> keys) async {
+    var s = Stopwatch()..start();
+    for (var key in keys) {
+      await store.getInt(key);
+    }
+    s.stop();
+    return s.elapsedMilliseconds;
+  }
+
+  @override
+  Future<int> batchReadString(List<String> keys) async {
+    var s = Stopwatch()..start();
+    for (var key in keys) {
+      await store.getString(key);
+    }
+    s.stop();
+    return s.elapsedMilliseconds;
+  }
+
+  @override
+  Future<int> batchWriteInt(Map<String, int> entries) async {
+    var s = Stopwatch()..start();
+    for (var key in entries.keys) {
+      await store.putInt(key, entries[key]);
+    }
+    s.stop();
+    return s.elapsedMilliseconds;
+  }
+
+  @override
+  Future<int> batchWriteString(Map<String, String> entries) async {
+    var s = Stopwatch()..start();
+    for (var key in entries.keys) {
+      await store.putString(key, entries[key]);
+    }
+    s.stop();
+    return s.elapsedMilliseconds;
+  }
+
+  @override
+  Future<int> batchDeleteInt(List<String> keys) async {
+    var s = Stopwatch()..start();
+    for (var key in keys) {
+      await store.deleteInt(key);
+    }
+    s.stop();
+    return s.elapsedMilliseconds;
+  }
+
+  @override
+  Future<int> batchDeleteString(List<String> keys) async {
+    var s = Stopwatch()..start();
+    for (var key in keys) {
+      await store.deleteString(key);
+    }
+    s.stop();
+    return s.elapsedMilliseconds;
+  }
+}

--- a/lib/sqlite_store.dart
+++ b/lib/sqlite_store.dart
@@ -9,7 +9,6 @@ class SqfliteStore {
   static const String TABLE_NAME_INT = "kv_int";
   Database db;
 
-  @override
   Future init() async {
     var dir = await getApplicationDocumentsDirectory();
     var dbPath = path.join(dir.path, 'sqlite.db');
@@ -30,7 +29,6 @@ class SqfliteStore {
     );
   }
 
-  @override
   Future<int> getInt(String key) async {
     var result = await db.query(
       TABLE_NAME_INT,
@@ -40,7 +38,6 @@ class SqfliteStore {
     return result[0]['value'] as int;
   }
 
-  @override
   Future putInt(String key, int value) {
     return db.insert(
       TABLE_NAME_INT,
@@ -49,7 +46,6 @@ class SqfliteStore {
     );
   }
 
-  @override
   Future deleteInt(String key) {
     return db.delete(
       TABLE_NAME_INT,
@@ -58,7 +54,6 @@ class SqfliteStore {
     );
   }
 
-  @override
   Future<String> getString(String key) async {
     var result = await db.query(
       TABLE_NAME_STR,
@@ -68,7 +63,6 @@ class SqfliteStore {
     return result[0]['value'] as String;
   }
 
-  @override
   Future putString(String key, String value) {
     return db.insert(
       TABLE_NAME_STR,
@@ -77,7 +71,6 @@ class SqfliteStore {
     );
   }
 
-  @override
   Future deleteString(String key) {
     return db.delete(
       TABLE_NAME_STR,
@@ -86,7 +79,6 @@ class SqfliteStore {
     );
   }
 
-  @override
   Future close() {
     return db.close();
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -33,7 +33,21 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.1.7"
+  moor:
+    dependency: transitive
+    description:
+      name: moor
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.7.2"
+  moor_ffi:
+    dependency: "direct main"
+    description:
+      name: moor_ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1"
   path:
     dependency: "direct main"
     description:
@@ -48,6 +62,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.8.0+1"
   pointycastle:
     dependency: transitive
     description:
@@ -103,5 +124,5 @@ packages:
     source: hosted
     version: "2.0.8"
 sdks:
-  dart: ">=2.2.2 <3.0.0"
+  dart: ">=2.5.0-dev <2.6.0"
   flutter: ">=1.5.0 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   sqflite: ^1.1.6
   shared_preferences: ^0.5.3+4
   fl_chart: ^0.1.6
-
+  moor_ffi: ^0.0.1
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
Thank you for providing this benchmark! It was very helpful while writing `moor_ffi`. This PR also runs the benchmark on a database accessed via `moor_ffi`. That might be interesting for some, but feel free to just close this PR if you don't think `moor_ffi` should be benchmarked in this project.

To reduce complexity in the benchmark class, I extracted each runner into an own file. If I didn't overlook anything, this shouldn't have any impact on the result. Please let me know if I some numbers look off to you.

## Results
Hive is still considerably faster than `moor_ffi`, but the ffi version is many times faster than `sqflite`. The benchmark also uses the raw database api exposed by `moor_ffi`, using it with moor will be slower.

I ran these benchmarks on a Pixel 3a with `flutter run --release` on the stable channel.

![grafik](https://user-images.githubusercontent.com/5738860/65551179-90eee180-df21-11e9-84e8-0181ec64c788.png)

Zoomed in results without sqflite:

![grafik](https://user-images.githubusercontent.com/5738860/65551241-bbd93580-df21-11e9-8884-5684160fc7fd.png)
![grafik](https://user-images.githubusercontent.com/5738860/65551247-c0055300-df21-11e9-99a3-64602f9810b6.png)
![grafik](https://user-images.githubusercontent.com/5738860/65551249-c4317080-df21-11e9-9a64-9ad26010a303.png)

Apart from the shockingly slow delete,  the results look quite promising. I'll try to diagnose what's causing the slow writes soon, but that's it for now.
