### PR TITLE
Update path_provider: ^2.0.8

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  path_provider: ^2.0.2
+  path_provider: ^2.0.8
   path: ^1.8.0
   random_string: ^2.2.0-nullsafety
   hive: ^2.0.4


### PR DESCRIPTION
App was crashing due to an old version of `path_provider` using a deprecated member from `path`